### PR TITLE
protect against missing mesh files or non-matching md5

### DIFF
--- a/polarrouteserver/route_api/utils.py
+++ b/polarrouteserver/route_api/utils.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 
 from django.conf import settings
@@ -134,3 +135,13 @@ def _closest_route_in_tolerance(
             routes_in_tolerance, key=itemgetter("cumulative_distance")
         )[0]
         return Route.objects.get(id=closest_route["id"])
+
+
+def calculate_md5(filename):
+    """create md5sum checksum for any file"""
+    hash_md5 = hashlib.md5()
+
+    with open(filename, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_md5.update(chunk)
+            return hash_md5.hexdigest()


### PR DESCRIPTION
Resolves #28 

+ Checks md5 hashes of the mesh file once read-in and cross-references against the one in the metadata file to check we're reading the file we think we are.
+ Protects against the file not being available, since the files listed in the metadata file may not have been fully transferred.