### PR TITLE
allow mesh metadata to be in a different directory to meshes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Configuration of PolarRouteServer works with environment variables. You can eith
 
 Environment variables used directly by the Django site are prefixed wit `POLARROUTE_` and those which configure Celery are prefixed with `CELERY_`.
 
-- `POLARROUTE_MESH_DIR` - absolute path to directory where mesh files and mesh metadata files will be made available (this location is periodically checked in production and new files ingested into the database based on the metadata file). A `UserWarning` is raised in production if this is not set.
+- `POLARROUTE_MESH_DIR` - absolute path to directory where mesh files will be made available (this location is periodically checked in production and new files ingested into the database based on the metadata file). A warning is logged in production if this is not set.
+- `POLARROUTE_MESH_METADATA_DIR` - as above, absolute path to directory where mesh metadata files will be made available. If this is not set, the value of `POLARROUTE_MESH_DIR` is used and a warning to this effect is logged.
 
 The following are inherited from Django and more information can be found on their effects via the [Django docs](https://docs.djangoproject.com/en/5.1/ref/settings/).
 - `POLARROUTE_DEBUG` - enables Django debug options, must be `False` in production (default: `False`)

--- a/polarrouteserver/route_api/tasks.py
+++ b/polarrouteserver/route_api/tasks.py
@@ -128,10 +128,13 @@ def optimise_route(
 def import_new_meshes(self):
     """Look for new meshes and insert them into the database."""
 
+    if settings.MESH_METADATA_DIR is None:
+        raise ValueError("MESH_METADATA_DIR has not been set.")
+
     # find the latest metadata file
-    files = os.listdir(settings.MESH_DIR)
+    files = os.listdir(settings.MESH_METADATA_DIR)
     file_list = [
-        os.path.join(settings.MESH_DIR, file)
+        os.path.join(settings.MESH_METADATA_DIR, file)
         for file in files
         if file.startswith("upload_metadata_") and file.endswith(".yaml.gz")
     ]
@@ -143,7 +146,7 @@ def import_new_meshes(self):
 
     # load in the metadata
     logger.info(
-        f"Loading metadata file from {os.path.join(settings.MESH_DIR,latest_metadata_file)}"
+        f"Loading metadata file from {os.path.join(settings.MESH_METADATA_DIR,latest_metadata_file)}"
     )
     with gzip.open(latest_metadata_file, "rb") as f:
         metadata = yaml.load(f.read(), Loader=yaml.Loader)

--- a/polarrouteserver/settings/base.py
+++ b/polarrouteserver/settings/base.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 BASE_DIR = os.getenv("POLARROUTE_BASE_DIR", os.getcwd())
 MESH_DIR = os.getenv("POLARROUTE_MESH_DIR", None)
+MESH_METADATA_DIR = os.getenv("POLARROUTE_MESH_METADATA_DIR", None)
 
 # NOTE: set this in production
 SECRET_KEY = os.getenv("POLARROUTE_SECRET_KEY", secrets.token_hex(100))

--- a/polarrouteserver/settings/production.py
+++ b/polarrouteserver/settings/production.py
@@ -6,12 +6,18 @@ from .base import *
 
 logger = logging.getLogger(__name__)
 
-if not MESH_DIR:
-    raise UserWarning(
-        "POLARROUTE_MESH_DIR not set, this is required to ingest new meshes into database.\n\
+if MESH_DIR is None:
+    logger.warning(
+        "POLARROUTE_MESH_DIR or POLARROUTE_MESH_METADATA_DIR not set, both are required to ingest new meshes into database.\n\
                    No new meshes will be automatically ingested."
     )
 else:
+    if MESH_METADATA_DIR is None:
+        MESH_METADATA_DIR = MESH_DIR
+        logger.warning(
+            f"POLARROUTE_MESH_METADATA_DIR not set. Using POLARROUTE_MESH_DIR as POLARROUTE_MESH_METADATA_DIR: {MESH_DIR}"
+        )
+
     CELERY_BEAT_SCHEDULE = {
         "import_meshes": {
             "task": "polarrouteserver.route_api.tasks.import_new_meshes",

--- a/polarrouteserver/settings/test.py
+++ b/polarrouteserver/settings/test.py
@@ -4,6 +4,7 @@ from .base import *
 
 TEST_MESH_PATH = Path("tests", "fixtures", "test_vessel_mesh.json")
 MESH_DIR = Path("tests", "fixtures")
+MESH_METADATA_DIR = MESH_DIR
 
 CELERY_BROKER_URL = "memory://"
 CELERY_RESULT_BACKEND = "db+sqlite:///results.sqlite"


### PR DESCRIPTION
As per discussion at https://github.com/antarctica/PolarRoute-pipeline/issues/51 this enables meshes and mesh metadata to be in different directories if necessary.