### PR TITLE
Return unsmoothed in place of smoothed routes

### DIFF
--- a/polarrouteserver/route_api/serializers.py
+++ b/polarrouteserver/route_api/serializers.py
@@ -18,3 +18,43 @@ class RouteSerializer(serializers.ModelSerializer):
             "polar_route_version",
             "info",
         ]
+
+    def to_representation(self, instance):
+        """Returns unsmoothed routes if available when smoothed routes have failed."""
+        data = super().to_representation(instance)
+
+        smoothed = {}
+        unsmoothed = {}
+        data["json"] = []
+        for key in ("traveltime", "fuel"):
+            smoothed[key] = (
+                [
+                    x
+                    for x in data["json"]
+                    if x[0]["features"][0]["properties"]["objective_function"] == key
+                ]
+                if data["json"] is not None
+                else []
+            )
+            unsmoothed[key] = (
+                [
+                    x
+                    for x in data["json_unsmoothed"]
+                    if x[0]["features"][0]["properties"]["objective_function"] == key
+                ]
+                if data["json_unsmoothed"] is not None
+                else []
+            )
+
+            # if there is no smoothed route available, use unsmoothed in its place
+            if len(smoothed[key]) == 0 and len(unsmoothed[key]) == 1:
+                data["json"].extend(unsmoothed[key])
+                data["info"] = {
+                    "error": f"Smoothing failed for {key}-optimisation, returning unsmoothed route."
+                }
+            elif len(smoothed[key]) == 0 and len(unsmoothed[key]) == 0:
+                data["info"] = {"error": f"No routes available for {key}-optimisation."}
+            else:
+                data["json"].extend(unsmoothed[key])
+
+        return data

--- a/polarrouteserver/route_api/views.py
+++ b/polarrouteserver/route_api/views.py
@@ -99,8 +99,6 @@ class RouteView(LoggingMixin, GenericAPIView):
         else:
             meshes = select_mesh(start_lat, start_lon, end_lat, end_lon)
 
-        logger.debug(f"Using meshes: {[mesh.id for mesh in meshes]}")
-
         if meshes is None:
             return Response(
                 data={
@@ -110,6 +108,8 @@ class RouteView(LoggingMixin, GenericAPIView):
                 headers={"Content-Type": "application/json"},
                 status=rest_framework.status.HTTP_200_OK,
             )
+
+        logger.debug(f"Using meshes: {[mesh.id for mesh in meshes]}")
         # TODO Future: calculate an up to date mesh if none available
 
         existing_route = route_exists(meshes, start_lat, start_lon, end_lat, end_lon)
@@ -152,7 +152,9 @@ class RouteView(LoggingMixin, GenericAPIView):
                     f"Found existing route(s) but got force_recalculate={force_recalculate}, beginning recalculation."
                 )
 
-        logger.debug(f"Using mesh {meshes[0].id} as primary mesh with {[mesh.id for mesh in meshes[1:]]} as backup.")
+        logger.debug(
+            f"Using mesh {meshes[0].id} as primary mesh with {[mesh.id for mesh in meshes[1:]]} as backup."
+        )
 
         # Create route in database
         route = Route.objects.create(


### PR DESCRIPTION
Addressing issue where if one of the two smoothing runs fails, the `json` field returned only has the one route.

With this change, if one of the route smoothing operations fails, the unsmoothed route is returned in its place, even if the other smoothing has succeeded.