### PR TITLE
And API endpoint to return mesh geojson

### DIFF
--- a/polarrouteserver/route_api/serializers.py
+++ b/polarrouteserver/route_api/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .models import Route
+from .models import Mesh, Route
 
 
 class RouteSerializer(serializers.ModelSerializer):
@@ -17,6 +17,7 @@ class RouteSerializer(serializers.ModelSerializer):
             "json_unsmoothed",
             "polar_route_version",
             "info",
+            "mesh",
         ]
 
     def to_representation(self, instance):
@@ -58,3 +59,14 @@ class RouteSerializer(serializers.ModelSerializer):
                 data["json"].extend(unsmoothed[key])
 
         return data
+
+
+class ModelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Mesh
+        fields = [
+            "id",
+        ]
+
+    def to_representation(self, instance):
+        return super().to_representation(instance)

--- a/polarrouteserver/route_api/views.py
+++ b/polarrouteserver/route_api/views.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import logging
 
 from celery.result import AsyncResult
+from meshiphi.mesh_generation.environment_mesh import EnvironmentMesh
 import rest_framework.status
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
@@ -271,4 +272,34 @@ class RecentRoutesView(LoggingMixin, GenericAPIView):
             response_data,
             headers={"Content-Type": "application/json"},
             status=rest_framework.status.HTTP_200_OK,
+        )
+
+
+class MeshView(LoggingMixin, GenericAPIView):
+    def get(self, request, id):
+        logger.info(
+            f"{request.method} {request.path} from {request.META.get('REMOTE_ADDR')}"
+        )
+
+        data = {}
+
+        try:
+            mesh = Mesh.objects.get(id=id)
+            data.update(
+                dict(
+                    id=mesh.id,
+                    json=mesh.json,
+                    geojson=EnvironmentMesh.load_from_json(mesh.json).to_geojson(),
+                )
+            )
+
+            status = rest_framework.status.HTTP_200_OK
+
+        except Mesh.DoesNotExist:
+            status = rest_framework.status.HTTP_204_NO_CONTENT
+
+        return Response(
+            data,
+            headers={"Content-Type": "application/json"},
+            status=status,
         )

--- a/polarrouteserver/urls.py
+++ b/polarrouteserver/urls.py
@@ -29,4 +29,5 @@ urlpatterns = [
         "api/route/<uuid:id>", views.RouteView.as_view(), name="route"
     ),  # url for retrieving routes (get)
     path("api/recent_routes", views.RecentRoutesView.as_view(), name="recent_routes"),
+    path("api/mesh/<int:id>", views.MeshView.as_view(), name="mesh"),
 ]

--- a/schema.yml
+++ b/schema.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: polarRouteServer
-  version: 0.0.1
+  version: 0.2.0
   description: Backend server for serving PolarRoute and MeshiPhi assets
 paths:
   /api/route:
@@ -58,6 +58,25 @@ paths:
       responses:
         '204':
           description: No response body
+  /api/mesh/{id}:
+     get:
+      operationId: api_mesh_get
+      description: Get mesh.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - api
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/mesh-response'
+          description: ''
 components:
   schemas:
     route-request:
@@ -113,4 +132,14 @@ components:
           type: string
           nullable: true
           maxLength: 60
+
+    mesh-response:
+      type: object
+      properties:
+        id: 
+          type: integer
+        json: 
+          type: object
+        geojson: 
+          type: object
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 import pytest
 
-from polarrouteserver.route_api.views import RouteView, RecentRoutesView
+from polarrouteserver.route_api.views import MeshView, RouteView, RecentRoutesView
 from polarrouteserver.route_api.models import Job, Route
 from .utils import add_test_mesh_to_db
 
@@ -167,11 +167,8 @@ class TestRouteStatus:
 
         assert response.status_code == 202
 
-@pytest.mark.usefixtures("celery_app","celery_worker", "celery_enable_logging")
-@pytest.mark.django_db
-class TestRecentRoutes:
+class TestGetRecentRoutesAndMesh(TestCase):
 
-    pytestmark = pytest.mark.django_db
 
     def setUp(self):
         self.factory = APIRequestFactory()
@@ -187,11 +184,19 @@ class TestRecentRoutes:
     
     def test_recent_routes_request(self):
 
-        self.setUp()
-
         request = self.factory.get(f"/api/recent_routes/")
 
         response = RecentRoutesView.as_view()(request)
 
         assert response.status_code == 200
         assert len(response.data) == 2
+
+    def test_mesh_get(self):
+
+        request = self.factory.get(f"/api/mesh/{self.mesh.id}")
+
+        response = MeshView.as_view()(request, self.mesh.id)
+
+        assert response.status_code == 200
+        assert response.data.get("json") is not None
+        assert response.data.get("geojson") is not None


### PR DESCRIPTION
This PR:
+ adds mesh id to route response,
+ adds an endpoint to get mesh json and geojson from id, at `/api/mesh/<id>`
+ adds a test for this behaviour,
+ simplifies the test class used, removing unrequired celery support,
+ adds description of this endpoint to the api schema