### PR TITLE
Move db volume from bind-mount to managed volume in compose config

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -28,7 +28,7 @@ services:
       POSTGRES_DB: polarroute
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
-      - ./data/db:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql/data
     ports:
       - 5432:5432
 
@@ -63,3 +63,6 @@ services:
       - BASE_URL=/swagger
     volumes:
       - ./schema.yml:/app/schema.yml
+
+volumes:
+  db-data:


### PR DESCRIPTION
I was having issues with things like running tests and installing local packages because of the bind-mounted postgres data volume in the same directory as the source code. This is because postgres has some python files in the data volume, which end up with root ownership because of docker, so things like pytest or pip discover the python files, but don't have permission to open them.

This moves from a bind-mounted volume to one managed by docker, which then gets put in a central docker volume location instead of the same directory as the project source code so should resolve this problem.