### PR TITLE
Force unique location names

### DIFF
--- a/polarrouteserver/route_api/models.py
+++ b/polarrouteserver/route_api/models.py
@@ -94,7 +94,7 @@ class Location(models.Model):
 
     lat = models.FloatField()
     lon = models.FloatField()
-    name = models.CharField(max_length=100)
+    name = models.CharField(max_length=100, unique=True)
 
     @property
     def latitude(self):


### PR DESCRIPTION
This is kind of a lazy/stopgap way of forcing unique locations, partially since I noticed the `loaddata` call might result in duplicate locations in the db.