### PR TITLE
Separate celery and django log configs; add warnings

### DIFF
--- a/polarrouteserver/settings/production.py
+++ b/polarrouteserver/settings/production.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import warnings
 
 from celery.schedules import crontab
 
@@ -27,6 +28,14 @@ else:
         },
     }
 
+polarroute_log_file_name = os.getenv("POLARROUTE_LOG_FILE_NAME", "polarrouteserver.log")
+polarroute_log_dir = os.getenv("POLARROUTE_LOG_DIR", None)
+if polarroute_log_dir is None:
+    polarroute_log_dir = Path(BASE_DIR, "logs")
+    warnings.warn(
+        f"CELERY_LOG_DIR not set. PolarRoute-server logs will be written to: {os.path.join(polarroute_log_dir, polarroute_log_file_name)}"
+    )
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -49,8 +58,8 @@ LOGGING = {
             "level": os.getenv("POLARROUTE_LOG_LEVEL", "INFO"),
             "class": "logging.handlers.RotatingFileHandler",
             "filename": os.path.join(
-                os.getenv("POLARROUTE_LOG_DIR", Path(BASE_DIR, "logs")),
-                "polarrouteserver.log",
+                polarroute_log_dir,
+                polarroute_log_file_name,
             ),
             "formatter": "verbose",
         },
@@ -64,6 +73,13 @@ LOGGING = {
     },
 }
 
+celery_log_file_name = os.getenv("CELERY_LOG_FILE_NAME", "celery.log")
+celery_log_dir = os.getenv("CELERY_LOG_DIR", None)
+if celery_log_dir is None:
+    celery_log_dir = Path(BASE_DIR, "logs")
+    warnings.warn(
+        f"CELERY_LOG_DIR not set. Celery logs will be written to: {os.path.join(celery_log_dir, celery_log_file_name)}"
+    )
 
 CELERY_LOGGING = {
     "version": 1,
@@ -79,8 +95,8 @@ CELERY_LOGGING = {
             "level": "INFO",
             "class": "logging.FileHandler",
             "filename": os.path.join(
-                os.getenv("CELERY_LOG_DIR", Path(BASE_DIR, "logs")),
-                "celery.log",
+                celery_log_dir,
+                celery_log_file_name,
             ),
             "formatter": "default",
         },


### PR DESCRIPTION
Turns out it's helpful to be able to put the celery logs in a separate location.