### PR TITLE
Improve the speed of the route admin panel

### DIFF
--- a/polarrouteserver/route_api/admin.py
+++ b/polarrouteserver/route_api/admin.py
@@ -26,7 +26,7 @@ class RouteAdmin(admin.ModelAdmin):
     def get_queryset(self, request):
         # Load only the fields necessary for the changelist view
         queryset = super().get_queryset(request)
-        return queryset.defer("json", "json_unsmoothed")
+        return queryset.defer("json", "json_unsmoothed", "mesh__json")
 
     list_select_related = ("mesh",)
 


### PR DESCRIPTION
FFS Turns out that the mesh json was getting loaded for every route..
On the dev machine this change loads ~37 routes in the route summary panel in about <1 second rather than ~22 seconds according to my "profiling" (i.e. counting).