### PR TITLE
enable debugging of dockerised app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ COPY pyproject.toml manage.py /usr/src/app/
 COPY polarrouteserver /usr/src/app/polarrouteserver
 
 RUN uv pip install --system -e .
-RUN uv pip install --system django-debug-toolbar
+RUN uv pip install --system django-debug-toolbar debugpy

--- a/compose.yml
+++ b/compose.yml
@@ -3,6 +3,7 @@ services:
     build: .
     ports:
       - 8000:8000
+      - 3000:3000
     environment:
       DJANGO_SETTINGS_MODULE: polarrouteserver.settings.development
       CELERY_BROKER_URL: amqp://guest:guest@rabbitmq

--- a/manage.py
+++ b/manage.py
@@ -4,12 +4,25 @@
 import os
 import sys
 
+from django.conf import settings
+
 
 def main():
     """Run administrative tasks."""
     os.environ.setdefault(
         "DJANGO_SETTINGS_MODULE", "polarrouteserver.settings.production"
     )
+
+    if settings.DEBUG:
+        if os.environ.get("RUN_MAIN") or os.environ.get("WERKZEUG_RUN_MAIN"):
+            try:
+                import debugpy
+
+                debugpy.listen(("0.0.0.0", 3000))
+                debugpy.wait_for_client()
+                print("Attached!")
+            except ImportError:
+                pass
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ polarrouteserver = [
 
 [project.optional-dependencies]
 dev = [
+    "debugpy",
     "django-debug-toolbar",
     "pre-commit",
     "pytest",


### PR DESCRIPTION
These changes will allow us to attach the debugpy debugger (i.e. from vscode or similar) to an app running in a docker container. Note that this requires a `launch.json` config such as:

```json
        {
            "name": "Debug Dockerised Django",
            "type": "debugpy",
            "request": "attach",
            "pathMappings": [
                {
                "localRoot": "${workspaceFolder}",
                "remoteRoot": "/usr/src/app"
                }
            ],
            "connect": {"host": "127.0.0.1", "port": 3000},
        },
```