### PR TITLE
fix setuptools scm and docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,6 @@ COPY --chmod=775 docker-entrypoint.sh .
 COPY pyproject.toml manage.py /usr/src/app/
 COPY polarrouteserver /usr/src/app/polarrouteserver
 
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=99.99.99
 RUN uv pip install --system -e .
 RUN uv pip install --system django-debug-toolbar


### PR DESCRIPTION
Whoops, my setuptools scm introduction (#180) broke the docker build because there's no git history in there!

This is not a great fix, but it allows the container to build. I'll come up with something better shortly.

When running with the compose setup here, the `_version.py` in your local src will get bind mounted and the docker setup will report that as the version.