### PR TITLE
rabbitmq transient queue fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
- 
- 
+
+### Fixed
+- Configured Celery to use durable, named queues to resolve `INTERNAL_ERROR - Feature 'transient_nonexcl_queues' is deprecated` error from RabbitMQ. Added `CELERY_TASK_QUEUES`, `CELERY_TASK_DEFAULT_QUEUE`, `CELERY_TASK_DEFAULT_EXCHANGE`, and `CELERY_TASK_DEFAULT_ROUTING_KEY` settings in `base.py`.
+
+
 ## 0.2.7 - 2025-12-22
 
 ### Added

--- a/polarrouteserver/settings/base.py
+++ b/polarrouteserver/settings/base.py
@@ -12,6 +12,8 @@ import logging
 import os
 import secrets
 
+from kombu import Queue
+
 from polarrouteserver._version import __version__ as polarrouteserver_version
 
 logger = logging.getLogger(__name__)
@@ -205,6 +207,12 @@ CELERY_WORKER_HIJACK_ROOT_LOGGER = True
 CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "amqp://guest:guest@localhost")
 CELERY_RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", "django-db")
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
+
+# Use durable queues to avoid RabbitMQ deprecation of transient_nonexcl_queues
+CELERY_TASK_QUEUES = (Queue("default", durable=True),)
+CELERY_TASK_DEFAULT_QUEUE = "default"
+CELERY_TASK_DEFAULT_EXCHANGE = "default"
+CELERY_TASK_DEFAULT_ROUTING_KEY = "default"
 
 
 # Routing settings (TODO: hardcoded, can / should these be exposed elsewhere?)


### PR DESCRIPTION
See #194 

Updates `base.py` to resolve `INTERNAL_ERROR - Feature 'transient_nonexcl_queues' is deprecated` error from RabbitMQ. See the [rabbitmq 4.3.0 release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.0).

Developed under time pressure for an external meeting, we may wish to review. Also [see changes on ansible](https://gitlab.data.bas.ac.uk/station-data-management/ansible/-/merge_requests/105).

Instead of this we might want to pin rabbitmq to `rabbitmq-server-4.2.5` in the `polarroute/tasks/main.yml` in ansible or (probably more maintainable) somehow through polarroute-server. 