### PR TITLE
add healthcheck endpoint and docker container healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
- 
+
+### Added
+- `/health/` endpoint and `HEALTHCHECK` in the Docker container. 
  
 ## 0.2.7 - 2025-12-22
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,3 +25,6 @@ ENV SETUPTOOLS_SCM_PRETEND_VERSION=99.99.99
 
 RUN uv pip install --system -e .
 RUN uv pip install --system django-debug-toolbar debugpy
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health/')" || exit 1

--- a/polarrouteserver/settings/base.py
+++ b/polarrouteserver/settings/base.py
@@ -95,6 +95,7 @@ INSTALLED_APPS = [
     "taggit",
     "polarrouteserver.route_api",
     "corsheaders",
+    "health_check",
 ]
 
 CORS_ALLOWED_ORIGINS = []
@@ -206,6 +207,19 @@ CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "amqp://guest:guest@localhost
 CELERY_RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", "django-db")
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 
+# django-health-check settings
+HEALTH_CHECKS = [
+    "health_check.Cache",
+    "health_check.DNS",
+    "health_check.Database",
+    "health_check.Storage",
+    "health_check.contrib.psutil.Disk",
+    "health_check.contrib.celery.Ping",
+    (
+        "health_check.contrib.rabbitmq.RabbitMQ",
+        {"amqp_url": CELERY_BROKER_URL},
+    ),
+]
 
 # Routing settings (TODO: hardcoded, can / should these be exposed elsewhere?)
 WAYPOINT_DISTANCE_TOLERANCE = 1  # Nautical Miles

--- a/polarrouteserver/urls.py
+++ b/polarrouteserver/urls.py
@@ -1,7 +1,9 @@
 from django.contrib import admin
+from django.conf import settings
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from health_check.views import HealthCheckView
 
 from polarrouteserver.route_api import views
 
@@ -56,6 +58,11 @@ urlpatterns = [
     path("api/mesh/<int:id>", views.MeshView.as_view(), name="mesh_detail"),
     path(
         "api/evaluate_route", views.EvaluateRouteView.as_view(), name="evaluate_route"
+    ),
+    path(
+        "health/",
+        HealthCheckView.as_view(checks=settings.HEALTH_CHECKS),
+        name="health_check",
     ),
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "django-celery-beat",
     "django-celery-results",
     "django-cors-headers",
+    "django-health-check[psutil,rabbitmq,celery]",
     "django-rest-framework",
     "django-taggit",
     "drf-spectacular[sidecar]",


### PR DESCRIPTION
resolve #149 

We might want a healthcheck for production-level container deployment environments. This adds a health check endpoint to the api and uses it in the docker image.

One drawback is that this isn't exposed to the DRF-spectacular generated apischema, but I'm not going to worry about that for now.