### PR TITLE
Create production docker setup

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,4 +25,7 @@ jobs:
       - name: Build
         uses: docker/build-push-action@v7
         with:
+          context: .
           push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,28 @@
+name: Test docker build
+
+on:
+  push:
+    branches:
+        - main
+  pull_request:
+    branches:
+        - main
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build
+        uses: docker/build-push-action@v7
+        with:
+          push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-# Dockerfile for polarrouteserver, intended for development use only
-
-FROM ghcr.io/astral-sh/uv:python3.13-trixie
+FROM ghcr.io/astral-sh/uv:python3.13-trixie AS dev
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
-ENV DJANGO_SETTINGS_MODULE=polarrouteserver.settings.development
+ENV DJANGO_SETTINGS_MODULE=polarrouteserver.settings.docker.development
 
 # Install GDAL - used by Fiona
 RUN apt-get update && apt-get install -y \
@@ -16,15 +14,52 @@ ENV GDAL_CONFIG=/usr/bin/gdal-config
 
 WORKDIR /usr/src/app
 
+# copy in everything for the dev stage, including the .git directory, importantly for dynamic versioning
+COPY . .
 COPY --chmod=775 docker-entrypoint.sh .
-
-COPY pyproject.toml manage.py /usr/src/app/
-COPY polarrouteserver /usr/src/app/polarrouteserver
-
-ENV SETUPTOOLS_SCM_PRETEND_VERSION=99.99.99
 
 RUN uv pip install --system -e .
 RUN uv pip install --system django-debug-toolbar debugpy
 
+# start prod build stage, using a lighter weight base image
+FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim AS prod
+
+RUN apt-get update && apt-get install -y \
+    gdal-bin \
+    libgdal-dev \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# create a non-root user (django) from which to run and serve the app
+RUN useradd -m -r django && \
+    mkdir /usr/src/app && \
+   chown -R django /usr/src/app
+
+# copy the python installation and packages from the dev stage
+COPY --from=dev --chown=django:django /usr/local/lib/python3.13/site-packages/ /usr/local/lib/python3.13/site-packages/
+COPY --from=dev --chown=django:django /usr/local/bin/ /usr/local/bin/
+
+WORKDIR /usr/src/app
+
+COPY --chown=django:django --chmod=775 docker-entrypoint.sh .
+COPY --chown=django:django pyproject.toml manage.py /usr/src/app/
+COPY --chown=django:django polarrouteserver /usr/src/app/polarrouteserver
+
+# set the settings module
+ENV DJANGO_SETTINGS_MODULE=polarrouteserver.settings.docker.production
+
+# install production dependencies including gunicorn
+RUN uv pip install --system --group production
+
+# set permissions on the python installed binaries
+RUN chown -R django:django /usr/local/bin
+
+# switch to the django user
+USER django
+
+# open port
+EXPOSE 8000
+
+# establish a healthcheck, using the django app's healthcheck endpoint
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health/')" || exit 1

--- a/compose.debug.yml
+++ b/compose.debug.yml
@@ -1,3 +1,6 @@
+# used for debugging, values here override those in compose.yml when used with docker compose -f compose.yml -f compose.debug.yml <COMMAND>
+# see developer documentation for more detail
+
 services:
   app:
     ports:

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,0 +1,18 @@
+# used for production settings, values here override those in compose.yml when used with docker compose -f compose.yml -f compose.prod.yml <COMMAND>
+
+services:
+  app:
+    build:
+      context: .
+      target: prod
+    environment:
+      DJANGO_SETTINGS_MODULE: polarrouteserver.settings.docker.production
+      POLARROUTE_STATIC_ROOT: /usr/src/app/static
+    command: ["gunicorn", "--bind", "0.0.0.0:8000", "--workers", "3", "polarrouteserver.wsgi:application", "--access-logfile", "-", "--error-logfile", "-"]
+
+  celery:
+    build:
+      context: .
+      target: prod
+    environment:
+      DJANGO_SETTINGS_MODULE: polarrouteserver.settings.docker.production

--- a/compose.yml
+++ b/compose.yml
@@ -1,10 +1,12 @@
 services:
   app:
-    build: .
+    build:
+      context: .
+      target: dev
     ports:
       - 8000:8000
     environment:
-      DJANGO_SETTINGS_MODULE: polarrouteserver.settings.development
+      DJANGO_SETTINGS_MODULE: polarrouteserver.settings.docker.development
       CELERY_BROKER_URL: amqp://guest:guest@rabbitmq
       POLARROUTE_MESH_DIR: /usr/src/app/mesh
       POLARROUTE_DB_HOST: db
@@ -35,9 +37,11 @@ services:
       - 5432:5432
 
   celery:
-    build: .
+    build:
+      context: .
+      target: dev
     environment:
-      DJANGO_SETTINGS_MODULE: polarrouteserver.settings.development
+      DJANGO_SETTINGS_MODULE: polarrouteserver.settings.docker.development
       CELERY_BROKER_URL: amqp://guest:guest@rabbitmq
       POLARROUTE_MESH_DIR: /usr/src/app/mesh
       POLARROUTE_DB_HOST: db

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 
 python manage.py migrate
 python manage.py ensure_adminuser --no-input
+python manage.py collectstatic --noinput
 python manage.py loaddata locations_bas.json
 
 exec "$@"

--- a/polarrouteserver/settings/base.py
+++ b/polarrouteserver/settings/base.py
@@ -74,9 +74,9 @@ CELERY_LOGGING = {
         },
     },
     "loggers": {
-        "celery": {"handlers": ["celery"], "level": "INFO", "propagate": False},
+        "celery": {"handlers": ["console"], "level": "INFO", "propagate": False},
     },
-    "root": {"handlers": ["default"], "level": "DEBUG"},
+    "root": {"handlers": ["console"], "level": "DEBUG"},
 }
 
 # Application definition
@@ -213,7 +213,6 @@ HEALTH_CHECKS = [
     "health_check.DNS",
     "health_check.Database",
     "health_check.Storage",
-    "health_check.contrib.psutil.Disk",
     "health_check.contrib.celery.Ping",
     (
         "health_check.contrib.rabbitmq.RabbitMQ",

--- a/polarrouteserver/settings/docker/development.py
+++ b/polarrouteserver/settings/docker/development.py
@@ -1,0 +1,4 @@
+from polarrouteserver.settings.base import *
+from polarrouteserver.settings.development import *
+
+STATIC_ROOT = os.getenv("POLARROUTE_STATIC_ROOT", None)

--- a/polarrouteserver/settings/docker/production.py
+++ b/polarrouteserver/settings/docker/production.py
@@ -1,0 +1,103 @@
+from celery.schedules import crontab
+
+from polarrouteserver.settings.base import *
+
+logger = logging.getLogger(__name__)
+
+if MESH_DIR is None:
+    pass
+    # disabling these warnings in settings modules until we can resolve https://github.com/bas-amop/PolarRoute-server/issues/49
+    # logger.warning(
+    #     "POLARROUTE_MESH_DIR or POLARROUTE_MESH_METADATA_DIR not set, both are required to ingest new meshes into database.\n\
+    #                No new meshes will be automatically ingested."
+    # )
+else:
+    if MESH_METADATA_DIR is None:
+        MESH_METADATA_DIR = MESH_DIR
+        # logger.warning(
+        #     f"POLARROUTE_MESH_METADATA_DIR not set. Using POLARROUTE_MESH_DIR as POLARROUTE_MESH_METADATA_DIR: {MESH_DIR}"
+        # )
+
+    CELERY_BEAT_SCHEDULE = {
+        "import_meshes": {
+            "task": "polarrouteserver.route_api.tasks.import_new_meshes",
+            "schedule": crontab(minute="*/10"),
+        },
+    }
+
+# whitenoise for static file serving, needs to be in specific middleware position https://whitenoise.readthedocs.io/en/stable/django.html
+MIDDLEWARE.insert(1, "whitenoise.middleware.WhiteNoiseMiddleware")
+
+STORAGES = {
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
+
+
+LOGLEVEL = os.environ.get("POLARROUTE_LOG_LEVEL", "INFO").upper()
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "console": {
+            "format": "%(asctime)s%(process)d/%(thread)d%(name)s%(funcName)s %(lineno)s%(levelname)s%(message)s",
+            "datefmt": "%Y/%m/%d %H:%M:%S",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "console",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": LOGLEVEL,
+    },
+    "loggers": {
+        # Catch all Django-specific logs
+        "django": {
+            "handlers": ["console"],
+            "level": LOGLEVEL,
+            "propagate": False,
+        },
+        # Catch all database queries (only prints if LOGLEVEL is DEBUG)
+        "django.db.backends": {
+            "handlers": ["console"],
+            "level": LOGLEVEL,
+            "propagate": False,
+        },
+    },
+}
+
+CELERY_LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "console": {
+            "format": "%(asctime)s%(process)d/%(thread)d%(name)s%(funcName)s %(lineno)s%(levelname)s%(message)s",
+            "datefmt": "%Y/%m/%d %H:%M:%S",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "console",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": LOGLEVEL,
+    },
+    "loggers": {
+        "celery": {
+            "handlers": ["console"],
+            "level": LOGLEVEL,
+            "propagate": False,
+        },
+    },
+}
+
+STATIC_ROOT = os.getenv("POLARROUTE_STATIC_ROOT", None)

--- a/polarrouteserver/settings/production.py
+++ b/polarrouteserver/settings/production.py
@@ -116,4 +116,4 @@ CELERY_LOGGING = {
     "root": {"handlers": ["default"], "level": "DEBUG"},
 }
 
-STATIC_ROOT = os.getenv("POLARROUTE_STATIC_ROOT", None)
+STATIC_ROOT = os.getenv("POLARROUTE_STATIC_ROOT", os.path.join(BASE_DIR, "static"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,6 @@ dev = [
     "pytest-django",
     "ruff",
 ]
-prod = [
-    "gunicorn"
-]
 build = [
     "build"
 ]
@@ -77,6 +74,10 @@ docs = [
     "mkdocs-include-markdown-plugin",
     "mkdocstrings[python]",
     "mkdocs-render-swagger-plugin",
+]
+production = [
+    "gunicorn",
+    "whitenoise",
 ]
 
 [project.scripts]


### PR DESCRIPTION
resolves #195 

We already have a dev-level docker image for polarroute-server. Time to make it production-ready.

 - [x] Use `slim` variant of the python image for the production image.
 - [x] Switch to a production-ready server, e.g. gunicorn.
 - [x] Run server as non-root user.
 - [x] Review static asset collection - & use whitenoise for static serving with gunicorn.
 - [x] Incorporate the git history at the dev build stage (but not prod) so that versioning is handled correctly.
 - [x] Handle logging in a way that's suitable for the container setting - note use of docker-specific settings modules.
 - [ ] ~~Push built images to an image registry~~ - maybe not required yet.
 - [ ] Test against the built image.
 - [ ] Think about whether we need to configure using a provided database rather than our own containerised db - env vars *should* cover this?
 - [ ] Consider scalability? Probably not an issue for this application.